### PR TITLE
Add VIN field to complaint form and email

### DIFF
--- a/packages/behin-complaint/src/Controllers/ComplaintController.php
+++ b/packages/behin-complaint/src/Controllers/ComplaintController.php
@@ -23,6 +23,7 @@ class ComplaintController extends Controller
             'first_name_last_name' => 'required|string|max:255',
             'national_code' => 'required|string|size:10',
             'mobile' => 'required|string|size:11',
+            'vin' => 'nullable|string|max:50',
             'business_name' => 'required|string|max:255',
             'manager_name' => 'required|string|max:255',
             'state' => 'required|string|max:255',

--- a/packages/behin-complaint/src/views/create.blade.php
+++ b/packages/behin-complaint/src/views/create.blade.php
@@ -36,6 +36,10 @@
                     <input type="text" name="mobile" class="form-control" value="{{ old('mobile') }}" required>
                 </div>
                 <div class="form-group">
+                    <label>شماره VIN خودرو:</label>
+                    <input type="text" name="vin" class="form-control" value="{{ old('vin') }}">
+                </div>
+                <div class="form-group">
                     <label>نام واحد صنفی:</label>
                     <input type="text" name="business_name" class="form-control" value="{{ old('business_name') }}"
                         required>

--- a/packages/behin-complaint/src/views/emails/complaint_submitted.blade.php
+++ b/packages/behin-complaint/src/views/emails/complaint_submitted.blade.php
@@ -48,6 +48,7 @@
         <p><strong>نام و نام خانوادگی:</strong> {{ $data['first_name_last_name'] ?? '' }}</p>
         <p><strong>کد ملی:</strong> {{ $data['national_code'] ?? '' }}</p>
         <p><strong>موبایل:</strong> {{ $data['mobile'] ?? '' }}</p>
+        <p><strong>شماره VIN خودرو:</strong> {{ $data['vin'] ?? '' }}</p>
         <p><strong>نام واحد صنفی:</strong> {{ $data['business_name'] ?? '' }}</p>
         <p><strong>نام مدیر واحد صنفی:</strong> {{ $data['manager_name'] ?? '' }}</p>
         <p><strong>استان:</strong> {{ $data['state'] ?? '' }}</p>


### PR DESCRIPTION
## Summary
- add a VIN input field to the complaint submission form
- validate and persist the VIN value so it appears in the notification email

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db8133dcfc833283a54e03a1d1df17