### PR TITLE
Update telegram ticket workflow statuses

### DIFF
--- a/packages/behin-telegram-ticket/src/Migrations/2025_08_05_113039_create_telegram_tickets_table.php
+++ b/packages/behin-telegram-ticket/src/Migrations/2025_08_05_113039_create_telegram_tickets_table.php
@@ -18,7 +18,7 @@ return new class extends Migration
             $table->bigInteger('user_id');
             $table->text('messages');
             $table->text('reply')->nullable();
-            $table->enum('status', ['open', 'closed'])->default('open');
+            $table->enum('status', ['open', 'answered', 'closed'])->default('open');
             $table->timestamps();
         });
     }

--- a/packages/behin-telegram-ticket/src/views/index.blade.php
+++ b/packages/behin-telegram-ticket/src/views/index.blade.php
@@ -1,8 +1,24 @@
 @extends('layouts.app')
 
+@php
+    use Illuminate\Support\Str;
+@endphp
+
 @section('content')
     <div class="container">
         <h3>لیست تیکت‌ها</h3>
+
+        <div class="mb-3">
+            <a href="{{ route('telegram-tickets.index', ['status' => 'open']) }}"
+                class="btn btn-sm {{ ($status ?? 'open') === 'open' ? 'btn-primary' : 'btn-outline-primary' }}">تیکت‌های باز</a>
+            <a href="{{ route('telegram-tickets.index', ['status' => 'answered']) }}"
+                class="btn btn-sm {{ ($status ?? 'open') === 'answered' ? 'btn-primary' : 'btn-outline-primary' }}">تیکت‌های پاسخ داده‌شده</a>
+            <a href="{{ route('telegram-tickets.index', ['status' => 'closed']) }}"
+                class="btn btn-sm {{ ($status ?? 'open') === 'closed' ? 'btn-primary' : 'btn-outline-primary' }}">تیکت‌های بسته شده</a>
+            <a href="{{ route('telegram-tickets.index', ['status' => 'all']) }}"
+                class="btn btn-sm {{ ($status ?? 'open') === 'all' ? 'btn-secondary' : 'btn-outline-secondary' }}">همه تیکت‌ها</a>
+        </div>
+
         @if ($tickets->isEmpty())
             <p>هیچ تیکتی برای نمایش وجود ندارد.</p>
         @else
@@ -22,7 +38,24 @@
                             <td>{{ $ticket->id }}</td>
                             <td>{{ $ticket->user_id }}</td> {{-- Assuming user_id can act as a name or you have a relation --}}
                             <td>{{ Str::limit($ticket->messages, 50) }}</td>
-                            <td>{{ $ticket->status == 'open' ? 'باز' : 'بسته' }}</td>
+                            <td>
+                                @switch($ticket->status)
+                                    @case('open')
+                                        باز
+                                    @break
+
+                                    @case('answered')
+                                        پاسخ داده‌شده
+                                    @break
+
+                                    @case('closed')
+                                        بسته شده
+                                    @break
+
+                                    @default
+                                        -
+                                @endswitch
+                            </td>
                             <td>
                                 <a href="{{ route('telegram-tickets.show', $ticket->id) }}" class="btn btn-info btn-sm">مشاهده</a>
                             </td>

--- a/packages/behin-telegram-ticket/src/views/show.blade.php
+++ b/packages/behin-telegram-ticket/src/views/show.blade.php
@@ -6,12 +6,30 @@
             <div class="card-body">
                 <h5 class="card-title">Ticket ID: {{ $ticket->id }}</h5>
                 <h6 class="card-subtitle mb-2 text-muted">User ID: {{ $ticket->user_id }}</h6>
-                <p class="card-text">وضعیت: {{ $ticket->status == 'open' ? 'باز' : 'بسته' }}</p>
+                <p class="card-text">
+                    وضعیت:
+                    @switch($ticket->status)
+                        @case('open')
+                            باز
+                        @break
+
+                        @case('answered')
+                            پاسخ داده‌شده
+                        @break
+
+                        @case('closed')
+                            بسته شده
+                        @break
+
+                        @default
+                            -
+                    @endswitch
+                </p>
                 <hr>
                 <p><strong>مکالمه:</strong></p>
                 <pre>{{ $ticket->messages }}</pre>
 
-                @if ($ticket->status == 'open')
+                @if ($ticket->status !== 'closed')
                     <form action="{{ route('telegram-tickets.reply', $ticket->id) }}" method="POST">
                         @csrf
                         <div class="form-group mt-3">
@@ -26,9 +44,10 @@
                     </form>
                 @else
                     <p class="mt-3">این تیکت بسته شده است.</p>
-                    @if ($ticket->reply)
-                        <p>پاسخ پشتیبان: {{ $ticket->reply }}</p>
-                    @endif
+                @endif
+
+                @if ($ticket->reply)
+                    <p class="mt-3">آخرین پاسخ پشتیبان: {{ $ticket->reply }}</p>
                 @endif
             </div>
         </div>


### PR DESCRIPTION
## Summary
- mark tickets as answered when a support reply is sent and persist the reply text
- expand the ticket status enum to include answered and surface the status in the UI
- add filtering controls so the list defaults to open tickets with quick access to answered and closed tickets

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dce3ebb7e88332afdaef17f1e77086