### PR TITLE
Persist telegram ticket dialogs as structured messages

### DIFF
--- a/packages/behin-telegram-ticket/src/Controllers/TelegramTicketController.php
+++ b/packages/behin-telegram-ticket/src/Controllers/TelegramTicketController.php
@@ -4,6 +4,7 @@ namespace TelegramTicket\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Auth;
 use TelegramTicket\Models\TelegramTicket;
 use BaleBot\Controllers\TelegramController;
 
@@ -17,7 +18,8 @@ class TelegramTicketController extends Controller
             $status = 'open';
         }
 
-        $tickets = TelegramTicket::latest()
+        $tickets = TelegramTicket::with('latestMessage')
+            ->latest()
             ->when($status !== 'all', function ($query) use ($status) {
                 $query->where('status', $status);
             })
@@ -28,25 +30,67 @@ class TelegramTicketController extends Controller
 
     public function show($id)
     {
-        $ticket = TelegramTicket::findOrFail($id);
+        $ticket = TelegramTicket::with(['messages.replyTo'])->findOrFail($id);
         return view('telegram-ticket::show', compact('ticket'));
     }
 
     public function reply($id, Request $request)
     {
-        $ticket = TelegramTicket::findOrFail($id);
-        $agentReply = $request->input('reply');
-        $ticket->messages .= "\n\n👨‍💼 پاسخ پشتیبان:\n" . $agentReply;
-        $ticket->reply = $agentReply;
+        $ticket = TelegramTicket::with('messages')->findOrFail($id);
+
+        if ($ticket->status === 'closed') {
+            return redirect()->back()->withErrors(['reply' => 'این تیکت بسته شده است و امکان پاسخ وجود ندارد.']);
+        }
+
+        $validated = $request->validate([
+            'reply' => ['required', 'string'],
+            'reply_to_message_id' => ['nullable', 'integer'],
+        ]);
+
+        $replyToMessage = null;
+        if (!empty($validated['reply_to_message_id'])) {
+            $replyToMessage = $ticket->messages()
+                ->where('id', $validated['reply_to_message_id'])
+                ->first();
+
+            if (!$replyToMessage) {
+                return redirect()->back()->withErrors(['reply_to_message_id' => 'پیام انتخاب شده معتبر نیست.']);
+            }
+        }
+
+        $agentReply = $validated['reply'];
+
+        $message = $ticket->messages()->create([
+            'sender_id' => Auth::id(),
+            'sender_type' => 'agent',
+            'message' => $agentReply,
+            'reply_to_message_id' => $replyToMessage?->id,
+        ]);
+
         $ticket->status = 'answered';
         $ticket->save();
 
-        // ارسال پیام به کاربر تلگرام
         $telegram = new TelegramController(config('bale_bot_config.TOKEN'));
-        $telegram->sendMessage([
+
+        $payload = [
             'chat_id' => $ticket->user_id,
-            'text' => "👨‍💼 پاسخ پشتیبان:\n{$agentReply}"
-        ]);
+            'text' => "👨‍💼 پاسخ پشتیبان:\n{$agentReply}",
+        ];
+
+        if ($replyToMessage && $replyToMessage->platform_message_id) {
+            $payload['reply_to_message_id'] = $replyToMessage->platform_message_id;
+        }
+
+        $response = $telegram->sendMessage($payload);
+
+        if (is_string($response)) {
+            $response = json_decode($response, true);
+        }
+
+        if (is_array($response) && isset($response['result']['message_id'])) {
+            $message->platform_message_id = $response['result']['message_id'];
+            $message->save();
+        }
 
         return redirect()->route('telegram-tickets.show', $ticket->id)->with('success', 'پاسخ ارسال شد.');
     }

--- a/packages/behin-telegram-ticket/src/Migrations/2025_08_05_113039_create_telegram_tickets_table.php
+++ b/packages/behin-telegram-ticket/src/Migrations/2025_08_05_113039_create_telegram_tickets_table.php
@@ -16,10 +16,26 @@ return new class extends Migration
         Schema::create('telegram_tickets', function (Blueprint $table) {
             $table->id();
             $table->bigInteger('user_id');
-            $table->text('messages');
-            $table->text('reply')->nullable();
             $table->enum('status', ['open', 'answered', 'closed'])->default('open');
             $table->timestamps();
+        });
+
+        Schema::create('telegram_ticket_messages', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('ticket_id')->constrained('telegram_tickets')->cascadeOnDelete();
+            $table->unsignedBigInteger('sender_id')->nullable();
+            $table->string('sender_type', 50);
+            $table->text('message');
+            $table->unsignedBigInteger('reply_to_message_id')->nullable();
+            $table->unsignedBigInteger('platform_message_id')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::table('telegram_ticket_messages', function (Blueprint $table) {
+            $table->foreign('reply_to_message_id')
+                ->references('id')
+                ->on('telegram_ticket_messages')
+                ->onDelete('set null');
         });
     }
 
@@ -30,6 +46,11 @@ return new class extends Migration
      */
     public function down()
     {
+        Schema::table('telegram_ticket_messages', function (Blueprint $table) {
+            $table->dropForeign(['reply_to_message_id']);
+        });
+
+        Schema::dropIfExists('telegram_ticket_messages');
         Schema::dropIfExists('telegram_tickets');
     }
 };

--- a/packages/behin-telegram-ticket/src/Models/TelegramTicket.php
+++ b/packages/behin-telegram-ticket/src/Models/TelegramTicket.php
@@ -3,13 +3,22 @@
 namespace TelegramTicket\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use TelegramTicket\Models\TelegramTicketMessage;
 
 class TelegramTicket extends Model
 {
     protected $fillable = [
         'user_id',
-        'messages',
-        'reply',
         'status'
     ];
+
+    public function messages()
+    {
+        return $this->hasMany(TelegramTicketMessage::class, 'ticket_id')->orderBy('created_at');
+    }
+
+    public function latestMessage()
+    {
+        return $this->hasOne(TelegramTicketMessage::class, 'ticket_id')->latestOfMany();
+    }
 }

--- a/packages/behin-telegram-ticket/src/Models/TelegramTicketMessage.php
+++ b/packages/behin-telegram-ticket/src/Models/TelegramTicketMessage.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace TelegramTicket\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TelegramTicketMessage extends Model
+{
+    protected $fillable = [
+        'ticket_id',
+        'sender_id',
+        'sender_type',
+        'message',
+        'reply_to_message_id',
+        'platform_message_id',
+    ];
+
+    public function ticket()
+    {
+        return $this->belongsTo(TelegramTicket::class, 'ticket_id');
+    }
+
+    public function replyTo()
+    {
+        return $this->belongsTo(self::class, 'reply_to_message_id');
+    }
+
+    public function replies()
+    {
+        return $this->hasMany(self::class, 'reply_to_message_id');
+    }
+}

--- a/packages/behin-telegram-ticket/src/views/index.blade.php
+++ b/packages/behin-telegram-ticket/src/views/index.blade.php
@@ -36,8 +36,8 @@
                     @foreach ($tickets as $ticket)
                         <tr>
                             <td>{{ $ticket->id }}</td>
-                            <td>{{ $ticket->user_id }}</td> {{-- Assuming user_id can act as a name or you have a relation --}}
-                            <td>{{ Str::limit($ticket->messages, 50) }}</td>
+                            <td>{{ $ticket->user_id }}</td>
+                            <td>{{ Str::limit(optional($ticket->latestMessage)->message, 50) }}</td>
                             <td>
                                 @switch($ticket->status)
                                     @case('open')

--- a/packages/behin-telegram-ticket/src/views/show.blade.php
+++ b/packages/behin-telegram-ticket/src/views/show.blade.php
@@ -1,5 +1,9 @@
 @extends('layouts.app')
 
+@php
+    use Illuminate\Support\Str;
+@endphp
+
 @section('content')
     <div class="container">
         <div class="card mb-3">
@@ -25,15 +29,81 @@
                             -
                     @endswitch
                 </p>
+
+                @if (session('success'))
+                    <div class="alert alert-success">{{ session('success') }}</div>
+                @endif
+
+                @if ($errors->any())
+                    <div class="alert alert-danger">
+                        <ul class="mb-0">
+                            @foreach ($errors->all() as $error)
+                                <li>{{ $error }}</li>
+                            @endforeach
+                        </ul>
+                    </div>
+                @endif
+
                 <hr>
                 <p><strong>مکالمه:</strong></p>
-                <pre>{{ $ticket->messages }}</pre>
+
+                <div class="conversation" style="max-height: 400px; overflow-y: auto;">
+                    @forelse ($ticket->messages as $message)
+                        <div class="mb-3">
+                            <div class="d-flex {{ $message->sender_type === 'agent' ? 'justify-content-end' : '' }}">
+                                <div class="p-3 border rounded {{ $message->sender_type === 'agent' ? 'bg-light' : 'bg-white' }}"
+                                    style="max-width: 75%;">
+                                    <div class="d-flex justify-content-between align-items-center mb-2">
+                                        <span>
+                                            @switch($message->sender_type)
+                                                @case('agent')
+                                                    👨‍💼 پشتیبان
+                                                @break
+
+                                                @case('bot')
+                                                    🤖 ربات
+                                                @break
+
+                                                @default
+                                                    👤 کاربر
+                                            @endswitch
+                                        </span>
+                                        <small class="text-muted">{{ optional($message->created_at)->format('Y-m-d H:i') }}</small>
+                                    </div>
+
+                                    @if ($message->replyTo)
+                                        <blockquote class="blockquote border-start ps-2 ms-2">
+                                            <small class="text-muted">
+                                                {{ Str::limit($message->replyTo->message, 120) }}
+                                            </small>
+                                        </blockquote>
+                                    @endif
+
+                                    <div class="message-content">{!! nl2br(e($message->message)) !!}</div>
+                                </div>
+                            </div>
+                        </div>
+                    @empty
+                        <p class="text-muted">پیامی برای این تیکت ثبت نشده است.</p>
+                    @endforelse
+                </div>
 
                 @if ($ticket->status !== 'closed')
-                    <form action="{{ route('telegram-tickets.reply', $ticket->id) }}" method="POST">
+                    <form action="{{ route('telegram-tickets.reply', $ticket->id) }}" method="POST" class="mt-4">
                         @csrf
+                        <div class="form-group">
+                            <label for="reply_to_message_id" class="form-label">ریپلای به پیام</label>
+                            <select name="reply_to_message_id" id="reply_to_message_id" class="form-select">
+                                <option value="">بدون ریپلای</option>
+                                @foreach ($ticket->messages->sortByDesc('created_at') as $message)
+                                    <option value="{{ $message->id }}" @selected(old('reply_to_message_id') == $message->id)>
+                                        {{ Str::limit($message->message, 80) }}
+                                    </option>
+                                @endforeach
+                            </select>
+                        </div>
                         <div class="form-group mt-3">
-                            <textarea name="reply" class="form-control" rows="3" placeholder="پاسخ خود را اینجا بنویسید..." required></textarea>
+                            <textarea name="reply" class="form-control" rows="3" placeholder="پاسخ خود را اینجا بنویسید..." required>{{ old('reply') }}</textarea>
                         </div>
                         <button type="submit" class="btn btn-primary mt-2">ارسال پاسخ</button>
                     </form>
@@ -44,10 +114,6 @@
                     </form>
                 @else
                     <p class="mt-3">این تیکت بسته شده است.</p>
-                @endif
-
-                @if ($ticket->reply)
-                    <p class="mt-3">آخرین پاسخ پشتیبان: {{ $ticket->reply }}</p>
                 @endif
             </div>
         </div>


### PR DESCRIPTION
## Summary
- replace the denormalized messages/reply columns with a dedicated telegram_ticket_messages table and Eloquent model
- update the ticket controller and blades to show threaded conversations and allow choosing a message to reply to while capturing Bale response IDs
- log incoming Bale and Telegram bot messages into the new table and seed tickets from feedback with structured user/bot messages

## Testing
- php -l packages/behin-bale-bot/src/Controllers/BotController.php && \
php -l packages/behin-telegram-bot/src/Controllers/BotController.php && \
php -l packages/behin-telegram-ticket/src/Controllers/TelegramTicketController.php && \
php -l packages/behin-telegram-ticket/src/Migrations/2025_08_05_113039_create_telegram_tickets_table.php && \
php -l packages/behin-telegram-ticket/src/Models/TelegramTicket.php && \
php -l packages/behin-telegram-ticket/src/Models/TelegramTicketMessage.php

------
https://chatgpt.com/codex/tasks/task_e_68e0ad2f0484833284d393b3d9e0acf0