### PR TITLE
Store Bale bot conversations in ticket message log

### DIFF
--- a/packages/behin-telegram-ticket/src/Migrations/2025_08_05_120000_add_platform_and_feedback_to_telegram_ticket_messages_table.php
+++ b/packages/behin-telegram-ticket/src/Migrations/2025_08_05_120000_add_platform_and_feedback_to_telegram_ticket_messages_table.php
@@ -1,0 +1,54 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('telegram_ticket_messages', function (Blueprint $table) {
+            if (!Schema::hasColumn('telegram_ticket_messages', 'platform')) {
+                $table->string('platform', 50)->nullable()->after('platform_message_id');
+            }
+            if (!Schema::hasColumn('telegram_ticket_messages', 'feedback')) {
+                $table->string('feedback', 20)->default('none')->after('platform');
+            }
+        });
+
+        Schema::table('telegram_tickets', function (Blueprint $table) {
+            if (!Schema::hasColumn('telegram_tickets', 'is_bot_generated')) {
+                $table->boolean('is_bot_generated')->default(false)->after('status');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('telegram_ticket_messages', function (Blueprint $table) {
+            if (Schema::hasColumn('telegram_ticket_messages', 'feedback')) {
+                $table->dropColumn('feedback');
+            }
+            if (Schema::hasColumn('telegram_ticket_messages', 'platform')) {
+                $table->dropColumn('platform');
+            }
+        });
+
+        Schema::table('telegram_tickets', function (Blueprint $table) {
+            if (Schema::hasColumn('telegram_tickets', 'is_bot_generated')) {
+                $table->dropColumn('is_bot_generated');
+            }
+        });
+    }
+};

--- a/packages/behin-telegram-ticket/src/Models/TelegramTicket.php
+++ b/packages/behin-telegram-ticket/src/Models/TelegramTicket.php
@@ -9,7 +9,12 @@ class TelegramTicket extends Model
 {
     protected $fillable = [
         'user_id',
-        'status'
+        'status',
+        'is_bot_generated',
+    ];
+
+    protected $casts = [
+        'is_bot_generated' => 'boolean',
     ];
 
     public function messages()

--- a/packages/behin-telegram-ticket/src/Models/TelegramTicketMessage.php
+++ b/packages/behin-telegram-ticket/src/Models/TelegramTicketMessage.php
@@ -13,6 +13,12 @@ class TelegramTicketMessage extends Model
         'message',
         'reply_to_message_id',
         'platform_message_id',
+        'platform',
+        'feedback',
+    ];
+
+    protected $casts = [
+        'feedback' => 'string',
     ];
 
     public function ticket()


### PR DESCRIPTION
## Summary
- persist Bale bot user and bot messages in `telegram_ticket_messages` with platform metadata and like/dislike tracking
- add a migration to extend ticket tables with platform, feedback, and bot conversation flags
- hide bot-generated tickets from the support panel while still allowing disliked answers to open a new human ticket

## Testing
- php -l packages/behin-bale-bot/src/Controllers/BotController.php
- php -l packages/behin-telegram-ticket/src/Controllers/TelegramTicketController.php
- php -l packages/behin-telegram-ticket/src/Models/TelegramTicket.php
- php -l packages/behin-telegram-ticket/src/Models/TelegramTicketMessage.php
- php -l packages/behin-telegram-ticket/src/Migrations/2025_08_05_120000_add_platform_and_feedback_to_telegram_ticket_messages_table.php

------
https://chatgpt.com/codex/tasks/task_e_68e0ca2c7f2883328914df85bf90b14f