### PR TITLE
Improve reply workflow in Telegram ticket view

### DIFF
--- a/packages/behin-telegram-ticket/src/views/show.blade.php
+++ b/packages/behin-telegram-ticket/src/views/show.blade.php
@@ -49,37 +49,44 @@
 
                 <div class="conversation" style="max-height: 400px; overflow-y: auto;">
                     @forelse ($ticket->messages as $message)
-                        <div class="mb-3">
-                            <div class="d-flex {{ $message->sender_type === 'agent' ? 'justify-content-end' : '' }}">
-                                <div class="p-3 border rounded {{ $message->sender_type === 'agent' ? 'bg-light' : 'bg-white' }}"
-                                    style="max-width: 75%;">
-                                    <div class="d-flex justify-content-between align-items-center mb-2">
-                                        <span>
-                                            @switch($message->sender_type)
-                                                @case('agent')
-                                                    👨‍💼 پشتیبان
-                                                @break
+                        <div class="mb-3 d-flex {{ $message->sender_type === 'agent' ? 'justify-content-end' : 'justify-content-start' }}">
+                            <div class="message-bubble {{ $message->sender_type === 'agent' ? 'message-bubble-agent' : 'message-bubble-user' }}"
+                                data-message-id="{{ $message->id }}"
+                                data-message-preview="{{ e(Str::limit($message->message, 120)) }}">
+                                <div class="d-flex justify-content-between align-items-center mb-2">
+                                    <span class="fw-semibold">
+                                        @switch($message->sender_type)
+                                            @case('agent')
+                                                👨‍💼 پشتیبان
+                                            @break
 
-                                                @case('bot')
-                                                    🤖 ربات
-                                                @break
+                                            @case('bot')
+                                                🤖 ربات
+                                            @break
 
-                                                @default
-                                                    👤 کاربر
-                                            @endswitch
-                                        </span>
-                                        <small class="text-muted">{{ optional($message->created_at)->format('Y-m-d H:i') }}</small>
-                                    </div>
+                                            @default
+                                                👤 کاربر
+                                        @endswitch
+                                    </span>
+                                    <small class="text-muted">{{ optional($message->created_at)->format('Y-m-d H:i') }}</small>
+                                </div>
 
-                                    @if ($message->replyTo)
-                                        <blockquote class="blockquote border-start ps-2 ms-2">
-                                            <small class="text-muted">
-                                                {{ Str::limit($message->replyTo->message, 120) }}
-                                            </small>
-                                        </blockquote>
-                                    @endif
+                                @if ($message->replyTo)
+                                    <blockquote class="blockquote border-start ps-2 ms-2 reply-reference">
+                                        <small class="text-muted">
+                                            {{ Str::limit($message->replyTo->message, 120) }}
+                                        </small>
+                                    </blockquote>
+                                @endif
 
-                                    <div class="message-content">{!! nl2br(e($message->message)) !!}</div>
+                                <div class="message-content">{!! nl2br(e($message->message)) !!}</div>
+
+                                <div class="text-end mt-3">
+                                    <button type="button" class="btn btn-sm btn-outline-primary reply-button"
+                                        data-message-id="{{ $message->id }}"
+                                        data-message-preview="{{ e(Str::limit($message->message, 120)) }}">
+                                        ریپلای
+                                    </button>
                                 </div>
                             </div>
                         </div>
@@ -91,17 +98,17 @@
                 @if ($ticket->status !== 'closed')
                     <form action="{{ route('telegram-tickets.reply', $ticket->id) }}" method="POST" class="mt-4">
                         @csrf
-                        <div class="form-group">
-                            <label for="reply_to_message_id" class="form-label">ریپلای به پیام</label>
-                            <select name="reply_to_message_id" id="reply_to_message_id" class="form-select">
-                                <option value="">بدون ریپلای</option>
-                                @foreach ($ticket->messages->sortByDesc('created_at') as $message)
-                                    <option value="{{ $message->id }}" @selected(old('reply_to_message_id') == $message->id)>
-                                        {{ Str::limit($message->message, 80) }}
-                                    </option>
-                                @endforeach
-                            </select>
+                        <input type="hidden" name="reply_to_message_id" id="reply_to_message_id"
+                            value="{{ old('reply_to_message_id') }}">
+
+                        <div id="reply-preview" class="alert alert-secondary d-none align-items-center justify-content-between">
+                            <div>
+                                در حال پاسخ به:
+                                <span id="reply-preview-text" class="fw-semibold"></span>
+                            </div>
+                            <button type="button" class="btn-close" aria-label="حذف" id="reply-preview-clear"></button>
                         </div>
+
                         <div class="form-group mt-3">
                             <textarea name="reply" class="form-control" rows="3" placeholder="پاسخ خود را اینجا بنویسید..." required>{{ old('reply') }}</textarea>
                         </div>
@@ -120,3 +127,85 @@
         <a href="{{ route('telegram-tickets.index') }}" class="btn btn-secondary mt-3">بازگشت به لیست تیکت‌ها</a>
     </div>
 @endsection
+
+@push('styles')
+    <style>
+        .conversation {
+            background-color: #f7f8fa;
+            padding: 1.5rem;
+            border-radius: 1rem;
+        }
+
+        .message-bubble {
+            max-width: 75%;
+            padding: 1rem 1.25rem;
+            border-radius: 1rem;
+            position: relative;
+            box-shadow: 0 0.5rem 1rem rgba(31, 45, 61, 0.08);
+        }
+
+        .message-bubble-user {
+            background: #ffffff;
+            border: 1px solid #e4e6ef;
+        }
+
+        .message-bubble-agent {
+            background: linear-gradient(135deg, #e0f0ff 0%, #f3f9ff 100%);
+            border: 1px solid #cfe2ff;
+        }
+
+        .reply-reference {
+            border-color: #0d6efd !important;
+        }
+    </style>
+@endpush
+
+@push('scripts')
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const replyInput = document.getElementById('reply_to_message_id');
+            const replyPreview = document.getElementById('reply-preview');
+            const replyPreviewText = document.getElementById('reply-preview-text');
+            const replyPreviewClear = document.getElementById('reply-preview-clear');
+
+            function showPreview(messageId, messageText) {
+                if (!replyPreview || !replyPreviewText || !replyInput) {
+                    return;
+                }
+
+                replyInput.value = messageId || '';
+
+                if (messageId) {
+                    replyPreviewText.textContent = messageText || '';
+                    replyPreview.classList.remove('d-none');
+                    replyPreview.classList.add('d-flex');
+                } else {
+                    replyPreviewText.textContent = '';
+                    replyPreview.classList.remove('d-flex');
+                    replyPreview.classList.add('d-none');
+                }
+            }
+
+            document.querySelectorAll('.reply-button').forEach(function (button) {
+                button.addEventListener('click', function () {
+                    const messageId = this.dataset.messageId;
+                    const messageText = this.dataset.messagePreview || '';
+                    showPreview(messageId, messageText);
+                });
+            });
+
+            if (replyPreviewClear) {
+                replyPreviewClear.addEventListener('click', function () {
+                    showPreview('', '');
+                });
+            }
+
+            if (replyInput && replyInput.value) {
+                const selectedMessage = document.querySelector('.reply-button[data-message-id="' + replyInput.value + '"]');
+                if (selectedMessage) {
+                    showPreview(replyInput.value, selectedMessage.dataset.messagePreview || '');
+                }
+            }
+        });
+    </script>
+@endpush


### PR DESCRIPTION
## Summary
- add inline reply buttons to each ticket message for quick selection
- replace the reply dropdown with a hidden field and contextual preview
- refresh the conversation styling for clearer message bubbles

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0eed648d48332b4862da247654f86