### PR TITLE
Improve advanced ticket category filtering

### DIFF
--- a/packages/altfuel-ticket/src/Controllers/TicketFilterController.php
+++ b/packages/altfuel-ticket/src/Controllers/TicketFilterController.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
 use IntlDateFormatter;
 use Mkhodroo\AltfuelTicket\Models\Ticket;
+use Mkhodroo\AltfuelTicket\Models\TicketCatagory;
 use Mkhodroo\AltfuelTicket\Models\TicketComment;
 use Morilog\Jalali\Jalalian;
 use Carbon\Carbon;
@@ -40,6 +41,9 @@ class TicketFilterController extends Controller
 
         if ($request->filled('filter_catagory')) {
             $query->where('cat_id', $request->filter_catagory);
+        } elseif ($request->filled('filter_parent_cat')) {
+            $categoryIds = $this->getDescendantCategoryIds($request->filter_parent_cat);
+            $query->whereIn('cat_id', $categoryIds);
         }
 
         $result = $query->get()->map(function ($row) {
@@ -87,6 +91,25 @@ class TicketFilterController extends Controller
         $persian = ['۰','۱','۲','۳','۴','۵','۶','۷','۸','۹'];
         $english = ['0','1','2','3','4','5','6','7','8','9'];
         return str_replace($persian, $english, $string);
+    }
+
+    private function getDescendantCategoryIds($categoryId, $categories = null)
+    {
+        if (is_null($categoryId)) {
+            return [];
+        }
+
+        $categories = $categories ?? TicketCatagory::all(['id', 'parent_id']);
+
+        $ids = collect([(int) $categoryId]);
+
+        $categories
+            ->where('parent_id', $categoryId)
+            ->each(function ($category) use (&$ids, $categories) {
+                $ids = $ids->merge($this->getDescendantCategoryIds($category->id, $categories));
+            });
+
+        return $ids->unique()->values()->all();
     }
 
 }

--- a/packages/altfuel-ticket/src/Views/partial-view/filter-form.blade.php
+++ b/packages/altfuel-ticket/src/Views/partial-view/filter-form.blade.php
@@ -61,7 +61,7 @@
         <label for="filter_child_cat">دسته بندی</label>
         <div class="row">
             <div class="col-md-6 mb-2 mb-md-0">
-                <select id="filter_parent_cat" class="form-control"></select>
+                <select id="filter_parent_cat" name="filter_parent_cat" class="form-control"></select>
             </div>
             <div class="col-md-6">
                 <select name="filter_catagory" id="filter_child_cat" class="form-control"></select>
@@ -110,6 +110,7 @@
             if (!parentId) {
                 childCat.html('');
                 childCat.append(new Option('انتخاب زیر دسته', ''));
+                childCat.val('');
                 return;
             }
 
@@ -122,6 +123,7 @@
             url = url.replace('parent_id', parentId);
             childCat.html('');
             childCat.append(new Option('انتخاب زیر دسته', ''));
+            childCat.val('');
 
             send_ajax_get_request(
                 url,


### PR DESCRIPTION
## Summary
- include the selected parent category in the advanced ticket filter form submission
- ensure the advanced filter returns tickets from the selected parent category and all of its descendants when no sub-category is chosen

## Testing
- php -l packages/altfuel-ticket/src/Controllers/TicketFilterController.php

------
https://chatgpt.com/codex/tasks/task_e_68e2046b8ef483328d66aa882a825d10