### PR TITLE
feat(telegram-ticket): support user file attachments

### DIFF
--- a/packages/behin-bale-bot/src/Controllers/BotController.php
+++ b/packages/behin-bale-bot/src/Controllers/BotController.php
@@ -4,7 +4,10 @@ namespace BaleBot\Controllers;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 use BaleBot\Models\BaleUser;
 use Mkhodroo\AltfuelTicket\Controllers\LangflowController;
 use TelegramTicket\Models\TelegramTicket;
@@ -84,6 +87,7 @@ class BotController extends Controller
         $message = $update['message'] ?? null;
         $chat_id = $message['chat']['id'] ?? null;
         $text = $message['text'] ?? null;
+        $caption = $message['caption'] ?? null;
         $contact = $message['contact'] ?? null;
         $incomingMessageId = $message['message_id'] ?? null;
         $replyToPlatformId = $message['reply_to_message']['message_id'] ?? null;
@@ -105,16 +109,25 @@ class BotController extends Controller
                     ->first();
             }
 
-            $messageContent = $text ?? '[بدون متن]';
+            $attachmentMeta = $this->extractAttachmentFromMessage($message);
+            $storedAttachment = $attachmentMeta ? $this->downloadBaleAttachment($telegram, $attachmentMeta) : null;
 
-            $openTicket->messages()->create([
+            $messageContent = trim((string)($text ?? $caption ?? ''));
+
+            $messageData = [
                 'sender_id' => $chat_id,
                 'sender_type' => 'user',
                 'message' => $messageContent,
                 'reply_to_message_id' => $replyTarget?->id,
                 'platform_message_id' => $incomingMessageId,
                 'platform' => 'bale',
-            ]);
+            ];
+
+            if ($storedAttachment) {
+                $messageData = array_merge($messageData, $storedAttachment);
+            }
+
+            $openTicket->messages()->create($messageData);
 
             $openTicket->status = 'open';
             $openTicket->save();
@@ -221,14 +234,25 @@ class BotController extends Controller
             }
 
             if (!$userMessage) {
-                $userMessage = $conversationTicket->messages()->create([
+                $attachmentMeta = $this->extractAttachmentFromMessage($message);
+                $storedAttachment = $attachmentMeta ? $this->downloadBaleAttachment($telegram, $attachmentMeta) : null;
+
+                $messageContent = trim((string)($text ?? $caption ?? ''));
+
+                $messagePayload = [
                     'sender_id' => $chat_id,
                     'sender_type' => 'user',
-                    'message' => $text,
+                    'message' => $messageContent,
                     'reply_to_message_id' => $replyTarget?->id,
                     'platform_message_id' => $incomingMessageId,
                     'platform' => 'bale',
-                ]);
+                ];
+
+                if ($storedAttachment) {
+                    $messagePayload = array_merge($messagePayload, $storedAttachment);
+                }
+
+                $userMessage = $conversationTicket->messages()->create($messagePayload);
             }
 
             $botResponse = LangflowController::run($text, $chat_id);
@@ -275,6 +299,136 @@ class BotController extends Controller
             ]);
             return;
         }
+    }
+
+    private function extractAttachmentFromMessage(array $message): ?array
+    {
+        $attachmentKeys = [
+            'document' => 'document',
+            'photo' => 'photo',
+            'audio' => 'audio',
+            'voice' => 'voice',
+            'video' => 'video',
+            'video_note' => 'video_note',
+            'animation' => 'animation',
+        ];
+
+        foreach ($attachmentKeys as $key => $type) {
+            if (empty($message[$key])) {
+                continue;
+            }
+
+            $fileData = $message[$key];
+            if ($key === 'photo') {
+                if (!is_array($fileData)) {
+                    continue;
+                }
+                $fileData = $fileData[array_key_last($fileData)] ?? null;
+            }
+
+            if (!is_array($fileData) || empty($fileData['file_id'])) {
+                continue;
+            }
+
+            return [
+                'type' => $type,
+                'file_id' => $fileData['file_id'],
+                'file_unique_id' => $fileData['file_unique_id'] ?? null,
+                'file_name' => $fileData['file_name'] ?? ($fileData['file_unique_id'] ?? null),
+                'mime_type' => $fileData['mime_type'] ?? ($type === 'photo' ? 'image/jpeg' : null),
+                'file_size' => $fileData['file_size'] ?? null,
+            ];
+        }
+
+        return null;
+    }
+
+    private function downloadBaleAttachment(TelegramController $telegram, array $attachmentMeta): ?array
+    {
+        try {
+            $fileResponse = $telegram->getFile($attachmentMeta['file_id']);
+        } catch (\Throwable $throwable) {
+            Log::error('Bale attachment getFile failed', [
+                'exception' => $throwable->getMessage(),
+            ]);
+            return null;
+        }
+
+        if (!is_array($fileResponse) || !($fileResponse['ok'] ?? false)) {
+            Log::warning('Bale attachment getFile returned invalid response', [
+                'response' => $fileResponse,
+            ]);
+            return null;
+        }
+
+        $filePath = $fileResponse['result']['file_path'] ?? null;
+        if (!$filePath) {
+            return null;
+        }
+
+        $downloadUrl = sprintf('https://tapi.bale.ai/file/bot%s/%s', config('bale_bot_config.TOKEN'), $filePath);
+
+        try {
+            $response = Http::timeout(30)->get($downloadUrl);
+        } catch (\Throwable $throwable) {
+            Log::error('Bale attachment download failed', [
+                'url' => $downloadUrl,
+                'exception' => $throwable->getMessage(),
+            ]);
+            return null;
+        }
+
+        if (!$response->successful()) {
+            Log::warning('Bale attachment download returned unsuccessful response', [
+                'url' => $downloadUrl,
+                'status' => $response->status(),
+            ]);
+            return null;
+        }
+
+        $extension = pathinfo($filePath, PATHINFO_EXTENSION);
+        if (!$extension && !empty($attachmentMeta['mime_type'])) {
+            $extension = $this->guessExtensionFromMime($attachmentMeta['mime_type']);
+        }
+
+        $filename = Str::uuid()->toString() . ($extension ? '.' . $extension : '');
+        $storageDirectory = 'telegram-ticket/' . ($attachmentMeta['type'] ?? 'attachments') . '/' . now()->format('Y/m/d');
+        $storagePath = $storageDirectory . '/' . $filename;
+
+        Storage::disk('public')->put($storagePath, $response->body());
+
+        return [
+            'attachment_path' => $storagePath,
+            'attachment_name' => $attachmentMeta['file_name'] ?? $filename,
+            'attachment_mime' => $attachmentMeta['mime_type'] ?? null,
+            'attachment_size' => $attachmentMeta['file_size'] ?? strlen($response->body()),
+        ];
+    }
+
+    private function guessExtensionFromMime(?string $mime): ?string
+    {
+        if (!$mime) {
+            return null;
+        }
+
+        $map = [
+            'image/jpeg' => 'jpg',
+            'image/png' => 'png',
+            'image/gif' => 'gif',
+            'image/webp' => 'webp',
+            'application/pdf' => 'pdf',
+            'application/zip' => 'zip',
+            'application/x-zip-compressed' => 'zip',
+            'audio/mpeg' => 'mp3',
+            'audio/ogg' => 'ogg',
+            'audio/webm' => 'webm',
+            'video/mp4' => 'mp4',
+            'video/quicktime' => 'mov',
+            'video/x-msvideo' => 'avi',
+            'text/plain' => 'txt',
+        ];
+
+        return $map[$mime] ?? null;
     }
 
     public function handleCallback($update)
@@ -332,6 +486,10 @@ class BotController extends Controller
                     'sender_id' => $message->sender_id,
                     'sender_type' => $message->sender_type,
                     'message' => $message->message,
+                    'attachment_path' => $message->attachment_path,
+                    'attachment_name' => $message->attachment_name,
+                    'attachment_mime' => $message->attachment_mime,
+                    'attachment_size' => $message->attachment_size,
                     'reply_to_message_id' => $message->reply_to_message_id ? ($idMap[$message->reply_to_message_id] ?? null) : null,
                     'platform_message_id' => $message->platform_message_id,
                     'platform' => $message->platform,

--- a/packages/behin-telegram-bot/src/Controllers/BotController.php
+++ b/packages/behin-telegram-bot/src/Controllers/BotController.php
@@ -4,7 +4,10 @@ namespace TelegramBot\Controllers;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 use Mkhodroo\AltfuelTicket\Controllers\LangflowController;
 use TelegramBot\Models\TelegramUser;
 use TelegramTicket\Models\TelegramTicket;
@@ -25,6 +28,7 @@ class BotController extends Controller
         $message = $update['message'] ?? null;
         $chat_id = $message['chat']['id'] ?? null;
         $text = $message['text'] ?? null;
+        $caption = $message['caption'] ?? null;
         $contact = $message['contact'] ?? null;
         $telegramMessageId = $message['message_id'] ?? null; // ✅ اضافه شد
         $replyToPlatformId = $message['reply_to_message']['message_id'] ?? null;
@@ -46,15 +50,24 @@ class BotController extends Controller
                     ->first();
             }
 
-            $messageContent = $text ?? '[بدون متن]';
+            $attachmentMeta = $this->extractAttachmentFromMessage($message);
+            $storedAttachment = $attachmentMeta ? $this->downloadTelegramAttachment($telegram, $attachmentMeta) : null;
 
-            $openTicket->messages()->create([
+            $messageContent = trim((string)($text ?? $caption ?? ''));
+
+            $messageData = [
                 'sender_id' => $chat_id,
                 'sender_type' => 'user',
                 'message' => $messageContent,
                 'reply_to_message_id' => $replyTarget?->id,
                 'platform_message_id' => $telegramMessageId,
-            ]);
+            ];
+
+            if ($storedAttachment) {
+                $messageData = array_merge($messageData, $storedAttachment);
+            }
+
+            $openTicket->messages()->create($messageData);
 
             $openTicket->status = 'open';
             $openTicket->save();
@@ -197,6 +210,136 @@ class BotController extends Controller
             ]);
             return;
         }
+    }
+
+    private function extractAttachmentFromMessage(array $message): ?array
+    {
+        $attachmentKeys = [
+            'document' => 'document',
+            'photo' => 'photo',
+            'audio' => 'audio',
+            'voice' => 'voice',
+            'video' => 'video',
+            'video_note' => 'video_note',
+            'animation' => 'animation',
+        ];
+
+        foreach ($attachmentKeys as $key => $type) {
+            if (empty($message[$key])) {
+                continue;
+            }
+
+            $fileData = $message[$key];
+            if ($key === 'photo') {
+                if (!is_array($fileData)) {
+                    continue;
+                }
+                $fileData = $fileData[array_key_last($fileData)] ?? null;
+            }
+
+            if (!is_array($fileData) || empty($fileData['file_id'])) {
+                continue;
+            }
+
+            return [
+                'type' => $type,
+                'file_id' => $fileData['file_id'],
+                'file_unique_id' => $fileData['file_unique_id'] ?? null,
+                'file_name' => $fileData['file_name'] ?? ($fileData['file_unique_id'] ?? null),
+                'mime_type' => $fileData['mime_type'] ?? ($type === 'photo' ? 'image/jpeg' : null),
+                'file_size' => $fileData['file_size'] ?? null,
+            ];
+        }
+
+        return null;
+    }
+
+    private function downloadTelegramAttachment(TelegramController $telegram, array $attachmentMeta): ?array
+    {
+        try {
+            $fileResponse = $telegram->getFile($attachmentMeta['file_id']);
+        } catch (\Throwable $throwable) {
+            Log::error('Telegram attachment getFile failed', [
+                'exception' => $throwable->getMessage(),
+            ]);
+            return null;
+        }
+
+        if (!is_array($fileResponse) || !($fileResponse['ok'] ?? false)) {
+            Log::warning('Telegram attachment getFile returned invalid response', [
+                'response' => $fileResponse,
+            ]);
+            return null;
+        }
+
+        $filePath = $fileResponse['result']['file_path'] ?? null;
+        if (!$filePath) {
+            return null;
+        }
+
+        $downloadUrl = sprintf('https://api.telegram.org/file/bot%s/%s', config('telegram_bot_config.TOKEN'), $filePath);
+
+        try {
+            $response = Http::timeout(30)->get($downloadUrl);
+        } catch (\Throwable $throwable) {
+            Log::error('Telegram attachment download failed', [
+                'url' => $downloadUrl,
+                'exception' => $throwable->getMessage(),
+            ]);
+            return null;
+        }
+
+        if (!$response->successful()) {
+            Log::warning('Telegram attachment download returned unsuccessful response', [
+                'url' => $downloadUrl,
+                'status' => $response->status(),
+            ]);
+            return null;
+        }
+
+        $extension = pathinfo($filePath, PATHINFO_EXTENSION);
+        if (!$extension && !empty($attachmentMeta['mime_type'])) {
+            $extension = $this->guessExtensionFromMime($attachmentMeta['mime_type']);
+        }
+
+        $filename = Str::uuid()->toString() . ($extension ? '.' . $extension : '');
+        $storageDirectory = 'telegram-ticket/' . ($attachmentMeta['type'] ?? 'attachments') . '/' . now()->format('Y/m/d');
+        $storagePath = $storageDirectory . '/' . $filename;
+
+        Storage::disk('public')->put($storagePath, $response->body());
+
+        return [
+            'attachment_path' => $storagePath,
+            'attachment_name' => $attachmentMeta['file_name'] ?? $filename,
+            'attachment_mime' => $attachmentMeta['mime_type'] ?? null,
+            'attachment_size' => $attachmentMeta['file_size'] ?? strlen($response->body()),
+        ];
+    }
+
+    private function guessExtensionFromMime(?string $mime): ?string
+    {
+        if (!$mime) {
+            return null;
+        }
+
+        $map = [
+            'image/jpeg' => 'jpg',
+            'image/png' => 'png',
+            'image/gif' => 'gif',
+            'image/webp' => 'webp',
+            'application/pdf' => 'pdf',
+            'application/zip' => 'zip',
+            'application/x-zip-compressed' => 'zip',
+            'audio/mpeg' => 'mp3',
+            'audio/ogg' => 'ogg',
+            'audio/webm' => 'webm',
+            'video/mp4' => 'mp4',
+            'video/quicktime' => 'mov',
+            'video/x-msvideo' => 'avi',
+            'text/plain' => 'txt',
+        ];
+
+        return $map[$mime] ?? null;
     }
 
     public function handleCallback()

--- a/packages/behin-telegram-ticket/src/Migrations/2025_08_05_130000_add_attachments_columns_to_telegram_ticket_messages_table.php
+++ b/packages/behin-telegram-ticket/src/Migrations/2025_08_05_130000_add_attachments_columns_to_telegram_ticket_messages_table.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('telegram_ticket_messages', function (Blueprint $table) {
+            if (!Schema::hasColumn('telegram_ticket_messages', 'attachment_path')) {
+                $table->string('attachment_path', 512)->nullable()->after('message');
+            }
+
+            if (!Schema::hasColumn('telegram_ticket_messages', 'attachment_name')) {
+                $table->string('attachment_name')->nullable()->after('attachment_path');
+            }
+
+            if (!Schema::hasColumn('telegram_ticket_messages', 'attachment_mime')) {
+                $table->string('attachment_mime', 120)->nullable()->after('attachment_name');
+            }
+
+            if (!Schema::hasColumn('telegram_ticket_messages', 'attachment_size')) {
+                $table->unsignedBigInteger('attachment_size')->nullable()->after('attachment_mime');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('telegram_ticket_messages', function (Blueprint $table) {
+            if (Schema::hasColumn('telegram_ticket_messages', 'attachment_size')) {
+                $table->dropColumn('attachment_size');
+            }
+
+            if (Schema::hasColumn('telegram_ticket_messages', 'attachment_mime')) {
+                $table->dropColumn('attachment_mime');
+            }
+
+            if (Schema::hasColumn('telegram_ticket_messages', 'attachment_name')) {
+                $table->dropColumn('attachment_name');
+            }
+
+            if (Schema::hasColumn('telegram_ticket_messages', 'attachment_path')) {
+                $table->dropColumn('attachment_path');
+            }
+        });
+    }
+};

--- a/packages/behin-telegram-ticket/src/Models/TelegramTicketMessage.php
+++ b/packages/behin-telegram-ticket/src/Models/TelegramTicketMessage.php
@@ -11,6 +11,10 @@ class TelegramTicketMessage extends Model
         'sender_id',
         'sender_type',
         'message',
+        'attachment_path',
+        'attachment_name',
+        'attachment_mime',
+        'attachment_size',
         'reply_to_message_id',
         'platform_message_id',
         'platform',
@@ -19,6 +23,7 @@ class TelegramTicketMessage extends Model
 
     protected $casts = [
         'feedback' => 'string',
+        'attachment_size' => 'integer',
     ];
 
     public function ticket()

--- a/packages/behin-telegram-ticket/src/views/index.blade.php
+++ b/packages/behin-telegram-ticket/src/views/index.blade.php
@@ -37,7 +37,14 @@
                         <tr>
                             <td>{{ $ticket->id }}</td>
                             <td>{{ $ticket->user_id }}</td>
-                            <td>{{ Str::limit(optional($ticket->latestMessage)->message, 50) }}</td>
+                            @php
+                                $latestMessage = $ticket->latestMessage;
+                                $latestPreview = optional($latestMessage)->message;
+                                if (!$latestPreview && $latestMessage && $latestMessage->attachment_name) {
+                                    $latestPreview = '📎 ' . $latestMessage->attachment_name;
+                                }
+                            @endphp
+                            <td>{{ Str::limit($latestPreview, 50) }}</td>
                             <td>
                                 @switch($ticket->status)
                                     @case('open')

--- a/packages/behin-telegram-ticket/src/views/show.blade.php
+++ b/packages/behin-telegram-ticket/src/views/show.blade.php
@@ -1,6 +1,7 @@
 @extends('layouts.app')
 
 @php
+    use Illuminate\Support\Facades\Storage;
     use Illuminate\Support\Str;
     $statusLabels = [
         'open' => ['label' => 'باز', 'class' => 'badge-success'],
@@ -103,16 +104,50 @@
                                     <span class="direct-chat-name">{{ $senderLabel }}</span>
                                     <span class="direct-chat-timestamp">{{ optional($message->created_at)->format('Y-m-d H:i') }}</span>
                                 </div>
+                                @php
+                                    $messagePreview = $message->message ?: ($message->attachment_name ? '📎 ' . $message->attachment_name : '');
+                                    $attachmentUrl = $message->attachment_path ? Storage::disk('public')->url($message->attachment_path) : null;
+                                    $isImageAttachment = $message->attachment_mime && Str::startsWith($message->attachment_mime, 'image/');
+                                @endphp
                                 <div class="direct-chat-text message-bubble"
                                     data-message-id="{{ $message->id }}"
-                                    data-message-preview="{{ e(Str::limit($message->message, 140)) }}">
+                                    data-message-preview="{{ e(Str::limit($messagePreview, 140)) }}">
                                     @if ($replyPreview)
                                         <div class="quoted-message mb-2">
                                             <i class="fa fa-reply ml-1"></i>
                                             <span class="text-muted">{{ $replyPreview }}</span>
                                         </div>
                                     @endif
-                                    <div class="message-content">{!! nl2br(e($message->message)) !!}</div>
+                                    <div class="message-content">
+                                        @if (filled($message->message))
+                                            {!! nl2br(e($message->message)) !!}
+                                        @elseif ($message->attachment_name)
+                                            <span class="text-muted">پیوست شده: {{ $message->attachment_name }}</span>
+                                        @endif
+                                    </div>
+                                    @if ($message->attachment_path && $attachmentUrl)
+                                        <div class="attachment-wrapper mt-2">
+                                            <a href="{{ $attachmentUrl }}" class="attachment-link" target="_blank" rel="noopener">
+                                                <i class="fa fa-paperclip ml-1"></i>
+                                                {{ $message->attachment_name ?? 'دانلود فایل پیوست' }}
+                                            </a>
+                                            @if ($message->attachment_mime || $message->attachment_size)
+                                                <div class="attachment-meta text-muted small mt-1">
+                                                    @if ($message->attachment_mime)
+                                                        <span>{{ $message->attachment_mime }}</span>
+                                                    @endif
+                                                    @if ($message->attachment_size)
+                                                        <span class="mr-2">{{ number_format($message->attachment_size / 1024, 1) }} کیلوبایت</span>
+                                                    @endif
+                                                </div>
+                                            @endif
+                                            @if ($isImageAttachment)
+                                                <div class="attachment-preview mt-2">
+                                                    <img src="{{ $attachmentUrl }}" alt="پیوست" class="img-fluid rounded">
+                                                </div>
+                                            @endif
+                                        </div>
+                                    @endif
                                 </div>
                                 <div class="message-actions mt-1">
                                     <button type="button" class="btn btn-link btn-sm p-0 reply-button"
@@ -348,6 +383,40 @@
         .message-actions .btn-link:hover {
             text-decoration: none;
             color: #367fa9;
+        }
+
+        .attachment-wrapper {
+            background-color: rgba(60, 141, 188, 0.08);
+            border-radius: 0.75rem;
+            padding: 0.75rem 1rem;
+        }
+
+        .direct-chat-msg.agent-message .attachment-wrapper {
+            background-color: rgba(37, 211, 102, 0.12);
+        }
+
+        .attachment-link {
+            font-weight: 600;
+            color: #1f2d3d;
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .direct-chat-msg.agent-message .attachment-link {
+            color: #0f5132;
+        }
+
+        .attachment-link:hover {
+            text-decoration: none;
+            color: #0c5460;
+        }
+
+        .attachment-preview img {
+            max-height: 220px;
+            object-fit: cover;
+            border-radius: 0.75rem;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
         }
     </style>
 @endsection


### PR DESCRIPTION
## Summary
- persist attachment metadata for telegram ticket messages and add a migration for the new fields
- download and store incoming Bale/Telegram bot files while preserving replies, forwarding the metadata into ticket messages
- render attachment previews and download links in the support views so agents can review uploaded files

## Testing
- php -l packages/behin-bale-bot/src/Controllers/BotController.php
- php -l packages/behin-telegram-bot/src/Controllers/BotController.php
- php -l packages/behin-telegram-ticket/src/Models/TelegramTicketMessage.php
- php -l packages/behin-telegram-ticket/src/Migrations/2025_08_05_130000_add_attachments_columns_to_telegram_ticket_messages_table.php


------
https://chatgpt.com/codex/tasks/task_e_68e378a3ad0c833287cd070a2e9403cb