### PR TITLE
Add search filtering to user list page

### DIFF
--- a/packages/mkhodroo-user-roles/src/Controllers/UserController.php
+++ b/packages/mkhodroo-user-roles/src/Controllers/UserController.php
@@ -48,12 +48,29 @@ class UserController extends Controller
 
     }
 
-    public function index($id)
+    public function index(Request $request, $id)
     {
         Access::check('user_show_all');
         if($id == 'all'):
-            $users = User::paginate(15);
-            return view('URPackageView::user.all')->with(['users' => $users]);
+            $search = $request->input('search');
+
+            $users = User::with('role')
+                ->when($search, function ($query) use ($search) {
+                    $query->where(function ($query) use ($search) {
+                        $query->where('display_name', 'like', "%{$search}%")
+                            ->orWhere('email', 'like', "%{$search}%")
+                            ->orWhereHas('role', function ($roleQuery) use ($search) {
+                                $roleQuery->where('name', 'like', "%{$search}%");
+                            });
+                    });
+                })
+                ->paginate(15)
+                ->withQueryString();
+
+            return view('URPackageView::user.all')->with([
+                'users' => $users,
+                'search' => $search
+            ]);
         else:
 
             return view('URPackageView::user.edit')->with([

--- a/packages/mkhodroo-user-roles/src/Views/user/all.blade.php
+++ b/packages/mkhodroo-user-roles/src/Views/user/all.blade.php
@@ -8,12 +8,19 @@
     <div class="container">
 
         <div class="card">
-            <div class="card-header">
-                <a href="{{ route('register') }}">
-                    <button class="btn btn-sm btn-primary">
-                        ایجاد کاربر
-                    </button>
-                </a>
+            <div
+                class="card-header d-flex flex-column gap-3 gap-md-0 flex-md-row justify-content-between align-items-md-center">
+                <div>
+                    <a href="{{ route('register') }}">
+                        <button class="btn btn-sm btn-primary">
+                            ایجاد کاربر
+                        </button>
+                    </a>
+                </div>
+                <form class="d-flex gap-2" method="GET" action="{{ route('user.all', 'all') }}">
+                    <input type="text" name="search" class="form-control" placeholder="جستجو بر اساس نام، نام کاربری یا نقش" value="{{ $search ?? '' }}">
+                    <button class="btn btn-sm btn-secondary" type="submit">جستجو</button>
+                </form>
             </div>
 
             <div class="card-body">


### PR DESCRIPTION
## Summary
- add a search form to the user list page to filter by name, username, or role
- update the user controller to apply search filters and persist query parameters across pagination

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b77cf338083328743be4b5607e29b)